### PR TITLE
ADTS-54 Research Develop and Implementation for solution.

### DIFF
--- a/client/src/components/GraphViewerComponent/GraphViewerRelationshipDeleteComponent/GraphViewerRelationshipDeleteComponent.js
+++ b/client/src/components/GraphViewerComponent/GraphViewerRelationshipDeleteComponent/GraphViewerRelationshipDeleteComponent.js
@@ -33,12 +33,10 @@ class GraphViewerRelationshipDeleteComponent extends Component {
 
   async deleteRelationship(edge) {
     try {
-      const { source } = edge;
-      let { id } = edge;
-      id = id.split("_").pop();
-      print(`*** Deleting relationship ${id}`, "info");
-      await apiService.deleteRelationship(source, id);
-      eventService.publishDeleteRelationship({ $sourceId: source, $relationshipId: id });
+      const { source, relationshipId } = edge;
+      print(`*** Deleting relationship ${relationshipId}`, "info");
+      await apiService.deleteRelationship(source, relationshipId);
+      eventService.publishDeleteRelationship({ $sourceId: source, $relationshipId: relationshipId });
     } catch (exc) {
       exc.customMessage = "Error deleting relationship";
       eventService.publishError(exc);


### PR DESCRIPTION
The logic behind deleting the relationship received a data object with all the edge info plus one ID created like this Origin_RelationshipID, and the delete execution split said ID and took the last value.

So in a normal named node like Person_Contain0 or in the case of the twin explorer that uses a GUID Person_344e7be-7bf5-48dc-b437-0361adb1d2b9 the last value of the split would work. But in the case where the RelationshipId had under scrolls in the actual ID it was spliting it and taking just the last part.

Two posible solutions for this was doing the split removing the first value and the concating the rest of the values into the ID we wanted to delete but I actually found this unnecessary since the edge data had the RelationshipId present so we should be using this instead. I did some testing to see if this was an issue and it doesn't look like the case. Let me know if we prefer the other solution to commit it.