### PR TITLE
ADTS-71

### DIFF
--- a/client/src/components/QueryComponent/QueryComponent.scss
+++ b/client/src/components/QueryComponent/QueryComponent.scss
@@ -275,7 +275,6 @@
 
 .ms-TextField.qc-query
 .ms-TextField-wrapper {
-  z-index: 101;
   position: fixed;
   margin-top: -38px;
   margin-left: 225px;
@@ -285,12 +284,8 @@
 .ms-TextField--multiline
 .ms-TextField-wrapper {
   z-index: 101;
-  position: fixed;
-  height: auto;
-  margin-top: 32px;
-  margin-left: 225px;
-  width: calc(100% - 550px);
 }
+
 
 .ms-TextField--multiline
 .ms-TextField-fieldGroup {


### PR DESCRIPTION
FIxed css to only override  z-index when on multiline state since we also wanted to be over the loader when the query was exetuted 